### PR TITLE
delimiter typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ $ `{{` `}}`
   <link rel="stylesheet" href="{{style.css}}">
 </head>
 <body>
-  <{}>
+  {{}}
 </body>
 </html>
 ```

--- a/doc/miniSnip.txt
+++ b/doc/miniSnip.txt
@@ -50,7 +50,7 @@ EXAMPLES                                                    *miniSnip-examples*
       <link rel="stylesheet" href="{{style.css}}">
     </head>
     <body>
-      <{}>
+      {{}}
     </body>
     </html>
 <


### PR DESCRIPTION
Fixes the incorrect delimiter in the HTML snippet example.