### PR TITLE
Handle being called between curly braces in completeMapping

### DIFF
--- a/autoload/miniSnip.vim
+++ b/autoload/miniSnip.vim
@@ -245,17 +245,13 @@ endfunction
 
 function! miniSnip#completeMapping() abort
   " Locate the start of the word
-  let l:line = getline('.')
-  let l:start = virtcol('.') - 1
-  while l:start > 0 && l:line[l:start - 1] =~? '\a'
-    let l:start -= 1
-  endwhile
-  let l:base = l:line[l:start : virtcol('.')-1]
-  if l:base is# ' '
-    let l:base = ''
+  let l:line = matchstr(getline('.'), '\a\+\%' . col('.') . 'c')
+  if l:line is# ' '
+    let l:line = ''
   endif
+  let l:start = virtcol('.') - len(l:line)
 
-  call complete(l:start + 1, miniSnip#completeFunc(0, l:base))
+  call complete(l:start, miniSnip#completeFunc(0, l:line))
   return ''
 endfunction
 


### PR DESCRIPTION
Previously if miniSnip#completeMapping() was called with a curly brace on the right like this

Let | be the cursor
```
fo|}
```

The following error would occur:
```
Error detected while processing function miniSnip#completeMapping[12]..miniSnip#completeFunc:
line   14:
E219: Missing {.
```

The issue was the miniSnip#completeMapping() did not remove the curly brace when calling for completion. This commit solves this by using regex to get only the text from the cursor to the first alphabetic character aka `\a`.

I chose `\a` since that was what ws previously used to determine the start of the word.

NOTE: This was not an issue for miniSnip#completeFunc()