### PR TITLE
docs: Correct typo in miniSnip_delimChg name

### DIFF
--- a/doc/miniSnip.txt
+++ b/doc/miniSnip.txt
@@ -285,7 +285,7 @@ Example: >
 `Shebang` is a description of snippet and `#!/usr/bin/env sh` its actual body.
 
 -------------------------------------------------------------------------------
-                                                        *'g:miniSnip_deli Chg'*
+                                                        *'g:miniSnip_delimChg'*
 Default: '$'
 
 If first (second if description was provided) line starts with `$`, then change


### PR DESCRIPTION
Add the missing "m" in the variable name