### PR TITLE
Fix typo on miniSnip_extends docs link

### DIFF
--- a/doc/miniSnip.txt
+++ b/doc/miniSnip.txt
@@ -24,7 +24,7 @@ Filetype-aware snippets are also available. For example, a file called
 |filetype|=java, allowing you to add a `main` for C, `main` for C++ and so on.
 
 You can also use snippets for one filetype in another (e.g. C snippets in C++).
-To do so, use |g:minSnip_extends|
+To do so, use |g:miniSnip_extends|
 
 Features:
   * default values of placeholders (e.g. `<{example}>`)


### PR DESCRIPTION
Update typo on doc link to properly hop using `C-]` navigation