### PR TITLE
Maybe not need ' undojoin '

### DIFF
--- a/autoload/miniSnip.vim
+++ b/autoload/miniSnip.vim
@@ -189,7 +189,7 @@ function! s:replaceRefs() abort
   let txt = escape(s:getInsertedText(), '/\\')
   let pos = getpos('.')
   let s:SNIP.count += 1
-  undojoin
+  "undojoin
 
   let cnt_pattern = substitute(s:SNIP.patterns.counted, "COUNT", s:SNIP.count, "")
   let boundries = (s:SNIP.pos.start).','.(s:SNIP.pos.end)

--- a/autoload/miniSnip.vim
+++ b/autoload/miniSnip.vim
@@ -189,7 +189,6 @@ function! s:replaceRefs() abort
   let txt = escape(s:getInsertedText(), '/\\')
   let pos = getpos('.')
   let s:SNIP.count += 1
-  "undojoin
 
   let cnt_pattern = substitute(s:SNIP.patterns.counted, "COUNT", s:SNIP.count, "")
   let boundries = (s:SNIP.pos.start).','.(s:SNIP.pos.end)


### PR DESCRIPTION
Echo error when I undo input words and after that I can't use <c-j> sniping  , So must del this snipwords or all undo if I want reuse 

---
Very comfortable to use when I remove ' undojoin '