### PR TITLE
Update: fix some bug

### DIFF
--- a/plugin/miniSnip.vim
+++ b/plugin/miniSnip.vim
@@ -24,7 +24,8 @@ let g:miniSnip_exppat   = get(g:, 'miniSnip_exppat',   '\w\+')
 
 inoremap <silent> <script> <expr> <Plug>(miniSnip) miniSnip#trigger()
 snoremap <silent> <script> <expr> <Plug>(miniSnip) miniSnip#trigger()
-nnoremap <silent> <script> <expr> <Plug>(miniSnip) miniSnip#clear()
+nnoremap <silent> <script> <expr> <Plug>(miniSnip) miniSnip#trigger()
+"nnoremap <silent> <script> <expr> <Plug>(miniSnip) miniSnip#clear()
 
 if !empty(g:miniSnip_trigger)
   execute "imap <unique> ".g:miniSnip_trigger." <Plug>(miniSnip)"


### PR DESCRIPTION
* Add getFlagSortNum function can find any sort flag+num in texts ( <{flag . '\d'}> )

* Fix bug
1 :  refmark count can't work if use undo
2 : refmark generate messy Hoop  string if not in the same line <c-j>
You can use undo and <c-j> will work fine now